### PR TITLE
Failing test for Model::getRepositoryForEntity

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -8,6 +8,14 @@ services:
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 	-
+		class: Nextras\OrmPhpStan\Types\ModelGetRepositoryReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Nextras\OrmPhpStan\Types\ModelGetRepositoryForEntityReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
 		class: Nextras\OrmPhpStan\Types\RelationshipReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Types/ModelGetRepositoryForEntityReturnTypeExtension.php
+++ b/src/Types/ModelGetRepositoryForEntityReturnTypeExtension.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\OrmPhpStan\Types;
+
+use Nextras\Orm\Model\IModel;
+use Nextras\Orm\Repository\IRepository;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantTypeHelper;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class ModelGetRepositoryForEntityReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+	/**
+	 * @var Broker
+	 */
+	private $broker;
+
+	/**
+	 * @var array<class-string<IEntity>, array<int, ConstantStringType>>
+	 */
+	private $repositoriesCache;
+
+	public function __construct(Broker $broker)
+	{
+		$this->broker = $broker;
+	}
+
+	public function getClass(): string
+	{
+		return IModel::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getRepositoryForEntity';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type {
+		if ($this->repositoriesCache === null) {
+			$this->repositoriesCache = $this->getRepositories();
+		}
+
+		$entityClassNameType = $scope->getType($methodCall->args[0]->value);
+
+		if (!$entityClassNameType instanceof ConstantStringType) {
+			throw new \Exception($entityClassNameType);
+			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		}
+
+		$entityClassName = $entityClassNameType->getValue();
+		if (!array_key_exists($entityClassName, $this->repositoriesCache)) {
+			throw new \Exception(print_r($this->repositoriesCache, true));
+			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		}
+
+		return TypeCombinator::union(...$this->repositoriesCache[$entityClassName]);
+	}
+
+	private function getRepositories(): array
+	{
+		$map = [];
+
+		foreach (get_declared_classes() as $class) {
+			if (!(new \ReflectionClass($class))->implementsInterface(IRepository::class)) {
+				continue;
+			}
+
+			foreach ($class::getEntityClassNames() as $entityClassName) {
+				$map[$entityClassName][] = ConstantTypeHelper::getTypeFromValue($class);
+			}
+		}
+
+		return $map;
+	}
+}

--- a/src/Types/ModelGetRepositoryReturnTypeExtension.php
+++ b/src/Types/ModelGetRepositoryReturnTypeExtension.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Nextras\OrmPhpStan\Types;
+
+use Nextras\Orm\Model\IModel;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class ModelGetRepositoryReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+	public function getClass(): string
+	{
+		return IModel::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getRepository';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type {
+		$repositoryClassNameType = $scope->getType($methodCall->args[0]->value);
+
+		if (!$repositoryClassNameType instanceof ConstantStringType) {
+			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+		}
+
+		return new ObjectType($repositoryClassNameType->getValue());
+	}
+}

--- a/tests/testbox/Types/ModelTypesTest.php
+++ b/tests/testbox/Types/ModelTypesTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace NextrasTests\OrmPhpStan\Types;
+
+use Nextras\Orm\Model\Model;
+use Nextras\Orm\Repository\IRepository;
+
+class ModelTypesTest
+{
+	public function testGetRepository(Model $em): AuthorsRepository
+	{
+		return $em->getRepository(AuthorsRepository::class);
+	}
+
+	public function testGetUnknownRepository(Model $em, string $repository): IRepository
+	{
+		return $em->getRepository($repository);
+	}
+
+	public function testGetRepositoryForEntity(Model $em): AuthorsRepository
+	{
+		return $em->getRepositoryForEntity(Author::class);
+	}
+
+	public function testGetEntityFromRepositoryForEntity(Model $em): ?Author
+	{
+		return $em->getRepositoryForEntity(Author::class)->getById(9);
+	}
+}


### PR DESCRIPTION
Would be nice to have dynamic return type extension for this method.
Or we can remove support for object resolution and add generics :)