### PR TITLE
Failing test case for #19

### DIFF
--- a/tests/testbox/Types/RepositoryTypesTest.php
+++ b/tests/testbox/Types/RepositoryTypesTest.php
@@ -32,6 +32,13 @@ class RepositoryTypesTest
 		/** @var IEntity $a */
 		$a = $repository->getById(1);
 		$this->takeAuthor($repository->persist($a));
+		
+		
+		/** @var AuthorsRepository|BooksRepository $someRepo */
+		$someRepo = $repository;
+		foreach ($someRepo->findAll() as $ent) {
+		
+		}
 	}
 
 


### PR DESCRIPTION
Adds failing test case for #19 but errors thrown are not clear.
```

F

-- FAILED: test.php
   Failed: '...epositoryTypesTest.php:0:Internal error: Call to undefined method P...' should be 
       ... '...epositoryTypesTest.php:12:Parameter #1 $author of method NextrasTes...'
   
   diff /tmp/orm-phpstan/tests/output/test.expected /tmp/orm-phpstan/tests/output/test.actual
   
   in tmp/orm-phpstan/tests/test.php(17) Assert::same($expected, $actual);


FAILURES! (1 test, 1 failure, 0.5 seconds)
```