### PR TITLE
SetValueMethodRule: Add support for asymmetric properties

### DIFF
--- a/src/Rules/SetValueMethodRule.php
+++ b/src/Rules/SetValueMethodRule.php
@@ -89,6 +89,10 @@ class SetValueMethodRule implements Rule
 		$property = $class->getProperty($fieldName, $scope);
 		$propertyType = $property->getWritableType();
 
+		if (!$property->isWritable()) {
+			$propertyType = $property->getReadableType();
+		}
+
 		if (!$propertyType->accepts($valueType, true)->yes()) {
 			return [sprintf(
 				'Entity %s: property $%s (%s) does not accept %s.',


### PR DESCRIPTION
In preparation for https://github.com/phpstan/phpstan-src/pull/2294

When the property is not writeable, the writeable type will be void.